### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@ A **free** and **unlimited** API for Google Translate :dollar::no_entry_sign:
 - Language correction 
 - Fast and reliable – it uses the same servers that [translate.google.com](https://translate.google.com) uses
 
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/GoogleTranslate/functions?utm_source=GoogleTranslateGitHub&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Run now on <b>RapidAPI</b>
+</a>
+</div>
+
 ## Install 
 
 ```


### PR DESCRIPTION
I've added a link to google Translate's functions page in RapidAPI. The platform will allow users to test and better understand the API before implementation. :)