### PR TITLE
use process.env.GOOGLE_TRANSLATE_API first

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function translate(text, opts) {
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var url = 'https://translate.google.com/translate_a/single';
+        var url = (process.env.GOOGLE_TRANSLATE_API || 'https://translate.google.com') + '/translate_a/single';
         var data = {
             client: 't',
             sl: opts.from,


### PR DESCRIPTION
In some countries, we can not access https://translate.google.com directly, but we can access https://translate.google.cn, so it's better to add an environment to overwrite the default API path.