### PR TITLE
Expose the pronunciation from the response

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function translate(text, opts) {
         return got(url).then(function (res) {
             var result = {
                 text: '',
+                pronunciation: '',
                 from: {
                     language: {
                         didYouMean: false,
@@ -74,6 +75,8 @@ function translate(text, opts) {
             body[0].forEach(function (obj) {
                 if (obj[0]) {
                     result.text += obj[0];
+                } else if (obj[2]) {
+                    result.pronunciation += obj[2];
                 }
             });
 

--- a/test.js
+++ b/test.js
@@ -33,6 +33,16 @@ test('translate from auto to dutch', async t => {
     }
 });
 
+test('test pronunciation', async t => {
+    try {
+        const res = await translate('translator', {from: 'auto', to: 'zh-CN'});
+
+        t.is(res.pronunciation, 'Fānyì zhě');
+    } catch (err) {
+        t.fail(err.code);
+    }
+});
+
 test('translate some english text setting the source language as portuguese', async t => {
     try {
         const res = await translate('translator', {from: 'pt', to: 'nl'});


### PR DESCRIPTION
The server response includes pronunciation (e.g. pinyin for chinese) which should be exposed in the library's response.