### PR TITLE
Update safe-eval to 0.4.0 due sandbox escaping vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "configstore": "^2.0.0",
     "google-translate-token": "latest",
     "got": "^6.3.0",
-    "safe-eval": "^0.3.0"
+    "safe-eval": "^0.4.0"
   },
   "devDependencies": {
     "ava": "^0.15.2",


### PR DESCRIPTION
Snyk reports Sandbox Escaping vulnerability in safe-eval 0.3.0. Remediation: Upgrade to safe-eval@0.4.0. See: https://snyk.io/test/npm/google-translate-api