### PR TITLE
Add custom region option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,13 @@ function translate(text, opts) {
 
     opts.from = opts.from || 'auto';
     opts.to = opts.to || 'en';
+    opts.region = opts.region || "com";
 
     opts.from = languages.getCode(opts.from);
     opts.to = languages.getCode(opts.to);
 
     return token.get(text).then(function (token) {
-        var url = 'https://translate.google.com/translate_a/single';
+        var url = `https://translate.google.${opts.region}/translate_a/single`;
         var data = {
             client: 't',
             sl: opts.from,


### PR DESCRIPTION
I add a region option, let diffent region can get fast speed to access server.
Example:
```javascript
translate('Hello!', {to: 'en', region: 'cn'})
      .then(console.log);
```